### PR TITLE
fix bug where navbar was disappearing when resizing the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,62 +1,41 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./assets/css/style.css" />
-    <title>OdeToCode</title>
 
-    <!--Bootstrap core CSS-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="./assets/css/style.css" />
+  <title>OdeToCode</title>
+
+  <!--Bootstrap core CSS-->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
     integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
 
 </head>
+
 <body>
 
-  <section>
-    <nav class="navbar" style="background-color: #e3f2fd;">
-        <!-- Navbar content -->
-        <nav class="navbar navbar-expand-lg bg-body-tertiary">
-            <div class="container-fluid">
-              <a class="navbar-brand" href="#">OdetoCode</a>
-              <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-              </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                  <li class="nav-item">
-                    <a class="nav-link active" aria-current="page" href="#">Go to My Poetry Journal</a>
-                  </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="#"> Find Me a Poem!</a>
-                  </li>
-                  <li class="nav-item dropdown">
-                    
-                    </a>
-                    <ul class="dropdown-menu">
-                      <li><a class="dropdown-item" href="#">Action</a></li>
-                      <li><a class="dropdown-item" href="#">Another action</a></li>
-                      <li><hr class="dropdown-divider"></li>
-                      <li><a class="dropdown-item" href="#">Something else here</a></li>
-                    </ul>
-                  </li>
-                  <li class="nav-item">
-                  </li>
-                </ul>
-                <!-- <form class="d-flex" role="search">
-                  <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-                  <button class="btn btn-outline-success" type="submit">Search</button>
-                </form> -->
-              </div>
-            </div>
-          </nav>
-      </nav>
-  </section>
+  <!-- NAVBAR START -->
+  <nav class="navbar navbar-expand-lg navbar-light bg-warning">
+    <a class="navbar-brand" href="#">Ode to Code</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
+      aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+      <div class="navbar-nav">
+        <a class="nav-item nav-link active" href="#">Home <span class="sr-only">(current)</span></a>
+        <a class="nav-item nav-link" href="#">My Poetry Journal</a>
+        <a class="nav-item nav-link" id="randomPoem" href="#">Find Me a Poem</a>
+      </div>
+    </div>
+  </nav>
+  <!-- NAVBAR END  -->
 
   <!-- INPUT SEARCH SECTION -->
   <section>
-    <div class="jumbotron d-flex justify-content-center">   <!-- Added d-flex and justify-content-center -->
+    <div class="jumbotron d-flex justify-content-center"> <!-- Added d-flex and justify-content-center -->
       <div class="col-md-10">
 
         <div class="row g-3 mt-2">
@@ -82,20 +61,23 @@
                 <option value="3" id="lines">Lines</option>
               </select>
 
-            </div>    
+            </div>
           </div>
 
           <div class="col-md-6">
-            <input type="text" class="form-control" id="main-input" placeholder="Enter author, title or lines">  <!-- Added id to be able to target this specific input -->                      
+            <input type="text" class="form-control" id="main-input" placeholder="Enter author, title or lines">
+            <!-- Added id to be able to target this specific input -->
           </div>
-          
+
           <div class="col-md-3">
-            <button class="btn btn-secondary btn-block" id="search-button">Search Poem</button>             <!-- Added id to target the search button -->           
-          </div>  
+            <button class="btn btn-secondary btn-block" id="search-button">Search Poem</button>
+            <!-- Added id to target the search button -->
+          </div>
 
         </div>
-        <div class="mt-3">              
-          <a data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample" class="advanced">
+        <div class="mt-3">
+          <a data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false"
+            aria-controls="collapseExample" class="advanced">
             Advance Search With Filters <i class="fa fa-angle-down"></i>
           </a>
 
@@ -104,19 +86,19 @@
             <div class="card card-body">
               <div class="row">
                 <div class="col-md-4">
-                  <input type="text" class="form-control" placeholder="Author" >        
+                  <input type="text" class="form-control" placeholder="Author">
                 </div>
                 <div class="col-md-4">
-                  <input type="text" class="form-control" placeholder="Title">        
-                </div> 
+                  <input type="text" class="form-control" placeholder="Title">
+                </div>
                 <div class="col-md-4">
-                  <input type="text" class="form-control" placeholder="Lines">      
+                  <input type="text" class="form-control" placeholder="Lines">
                 </div>
               </div>
             </div>
+          </div>
         </div>
       </div>
-    </div>
   </section>
 
   <!-- Poems of the Day -->
@@ -189,12 +171,13 @@
   </section>
 
 
-    
 
-    <!-- jQuery JS -->
+
+  <!-- jQuery JS -->
   <script src="https://code.jquery.com/jquery.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-    <!-- Code to the JavaScript File -->
+  <!-- Code to the JavaScript File -->
   <script src="assets/js/script.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
Replaced navbar element as previous one had 2 nav elements encapsulated within each other, which was causing the navbar links to disappear when page was resized to mimic a smaller screen. Furthermore, it looks like from what I can see here - https://getbootstrap.com/docs/4.0/components/navbar/ - and here - https://stackoverflow.com/questions/48320543/bootstrap-4-navbar-disappears-when-resizing-screen - the use of container-fluid class in the navbar would cause it to strech across the entire screen, which might also make it disappear or display in a strange manner. The navbar now in place switches from displaying the links horizontally to a hamburger menu on screen resize, inside which the links can be accessed.