### PR TITLE
Replace alert by a modal when no search option selected

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -60,7 +60,8 @@ function getPoem () {
 
         // If nothing is selected
         else {
-            alert("Please select a search parameter.")
+            // alert("Please select a search parameter.")
+            $("#no-search-by").modal("show");
         }
 
         // Call to the API using one of the queryURL value above   

--- a/index.html
+++ b/index.html
@@ -168,6 +168,26 @@
 
     </section>
 
+    <!-- MT Adding modal to alert when no search option selected -->
+    <!-- Modal -->
+    <div class="modal fade" id="no-search-by" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLabel">No search options selected</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            Please select a search parameter.
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
 
 
   <!-- jQuery JS -->


### PR DESCRIPTION
As per project criteria, replaced the alert popping up when an input is added but no search option is selected by a modal. 